### PR TITLE
Fix exec path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Puppet module for installing and managing [Kongfig](https://github.com/mybuilder
 This module is currently tested on:
 
  - Debian (8.0, 7.8)
+ - Ubuntu (14.04)
 
 It may work on other distros.
 
@@ -55,7 +56,7 @@ $consumers = [
 ]
 
 kongfig::setup { 'test-api':
-  kong_server => 127.0.0.1,
+  kong_server => '127.0.0.1',
   kong_port   => 8001,
   apis        => $apis,
   consumers   => $consumers

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,6 @@
 class kongfig::config {
   file { $kongfig::directory:
     ensure => directory,
-    owner  => 'root'
+    owner  => 'root',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # Setup kongfig the tool for configuring kong
 class kongfig (
   $directory = $kongfig::params::directory,
-  $version = $kongfig::params::version
+  $version = $kongfig::params::version,
 ) inherits kongfig::params {
 
   validate_absolute_path($directory)

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -16,7 +16,7 @@ define kongfig::setup (
   if $apis {
     validate_array($apis)
     $api_hash = {
-      'apis' => $apis
+      'apis' => $apis,
     }
   }
 
@@ -24,7 +24,7 @@ define kongfig::setup (
     validate_array($consumers)
 
     $consumer_hash = {
-      'consumers' => $consumers
+      'consumers' => $consumers,
     }
   }
 
@@ -35,7 +35,7 @@ define kongfig::setup (
   file { $config:
     ensure  => file,
     content => sorted_json(merge($host, $api_hash, $consumer_hash), true, 4),
-    require => [File[$kongfig::directory], Package['kongfig']]
+    require => [File[$kongfig::directory], Package['kongfig']],
   }->
   exec { $name:
     command => "kongfig --path ${config}",

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -39,6 +39,7 @@ define kongfig::setup (
   }->
   exec { $name:
     command => "kongfig --path ${config}",
-    require => Package['kongfig']
+    require => Package['kongfig'],
+    path    => [ "/usr/bin/", "/usr/local/bin/" ],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,10 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": ["7", "8"]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": ["14.04"]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Hi Gavin 

Puppet 3.x does not allow unqualified exec commands. This adds the fully qualified path to kongfig.
I have also fixed some unrelated linter warnings.

Developed by _Catalyst Net Ltd_, sponsored by _Museum of New Zealand Te Papa Tongarewa_.
