### PR TITLE
Only apply config if changes were made

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -33,12 +33,14 @@ define kongfig::setup (
   $config = "${kongfig::directory}/${name}.json"
 
   file { $config:
-    ensure  => file,
-    content => sorted_json(merge($host, $api_hash, $consumer_hash), true, 4),
-    require => [File[$kongfig::directory], Package['kongfig']]
-  }->
+      ensure  => file,
+      content => sorted_json(merge($host, $api_hash, $consumer_hash), true, 4),
+      require => [File[$kongfig::directory], Package['kongfig']]
+   }
+
   exec { $name:
     command => "kongfig --path ${config}",
-    require => Package['kongfig']
+    subscribe   => File[$config],
+    refreshonly => true
   }
 }


### PR DESCRIPTION
Hi @gavinlove,

This PR prevents the module from applying the config on every Puppet run. 

Kongfig will fetch all data first from the server before applying changes. If this happens on every Puppet run, our server is hammered continuously with GET requests to retrieve consumer info. If you have thousands of consumers this is a bit overkill :)

Thanks,
Steven
